### PR TITLE
change lineitem.quantity from integer to double

### DIFF
--- a/src/main/java/io/airlift/tpch/LineItem.java
+++ b/src/main/java/io/airlift/tpch/LineItem.java
@@ -102,9 +102,14 @@ public class LineItem
         return lineNumber;
     }
 
-    public long getQuantity()
+    public double getQuantity()
     {
         return quantity;
+    }
+
+    public long getQuantityUnscaled()
+    {
+        return quantity * 100;
     }
 
     public double getExtendedPrice()

--- a/src/main/java/io/airlift/tpch/LineItemColumn.java
+++ b/src/main/java/io/airlift/tpch/LineItemColumn.java
@@ -58,11 +58,16 @@ public enum LineItemColumn
                 }
             },
 
-    QUANTITY("quantity", BIGINT)
+    QUANTITY("quantity", DOUBLE)
             {
-                public long getLong(LineItem lineItem)
+                public double getDouble(LineItem lineItem)
                 {
                     return lineItem.getQuantity();
+                }
+
+                public long getLong(LineItem lineItem)
+                {
+                    return lineItem.getQuantityUnscaled();
                 }
             },
 


### PR DESCRIPTION
This change is required to conform to the TPC-H spec. The 2.17.1 version
states that the lineitem.l_quantity field should be of decimal type (page
17), as opposed to the currently implemented integer.

This particular discrepancy is visible in Presto, when it causes the
average of the quantity field to be returned as a double, because it uses the
avg(bigint):double function, as opposed to avg(decimal):decimal which is
part of the decimal implementation currently in multi-stage review in the
Presto project.
